### PR TITLE
Export State Module

### DIFF
--- a/programs/drift_vaults/src/lib.rs
+++ b/programs/drift_vaults/src/lib.rs
@@ -7,7 +7,7 @@ mod drift_cpi;
 mod error;
 mod instructions;
 pub mod macros;
-mod state;
+pub mod state;
 mod tests;
 mod token_cpi;
 

--- a/programs/drift_vaults/src/state/mod.rs
+++ b/programs/drift_vaults/src/state/mod.rs
@@ -8,10 +8,10 @@ pub use withdraw_unit::*;
 
 pub mod account_maps;
 pub mod events;
-mod tokenized_vault_depositor;
+pub mod tokenized_vault_depositor;
 pub mod traits;
-mod vault;
-mod vault_depositor;
-mod vault_protocol;
+pub mod vault;
+pub mod vault_depositor;
+pub mod vault_protocol;
 pub mod withdraw_request;
-mod withdraw_unit;
+pub mod withdraw_unit;


### PR DESCRIPTION
Making the `state` module public allows other programs which list drift-vaults as a dependency to import that data